### PR TITLE
【WIP】ツール入力機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "font-awesome-sass", "~> 6.4.0"
 gem 'sorcery', '0.16.4'
 gem 'pry-byebug'
 gem 'rails-i18n', '~> 6.0'
+gem 'cocoon'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -272,6 +273,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  cocoon
   font-awesome-sass (~> 6.4.0)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
+  before_action :require_login
+
+  private
+
+  def not_authenticated
+    flash[:warning] = t('defaults.message.require_login')
+    redirect_to login_path
+  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: %i[top]
+  
   def top; end
 end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -1,0 +1,32 @@
+class ToolsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create show]
+
+  def index
+    @tools = Tool.all.includes(:user).order(created_at: :desc)
+  end
+
+  def new
+    @tool = Tool.new
+    @tool_units = @tool.tool_units.build
+  end
+
+  def create
+    @tool = current_user.tools.build(tool_params)
+    if @tool.save
+      redirect_to tool_path(@tool), success: t('.success')
+    else
+      flash.now['danger'] = t('.fail')
+      render :new
+    end
+  end
+
+  def show
+    @tool = Tool.find(params[:id])
+  end
+
+  private
+
+  def tool_params
+    params.require(:tool).permit(:store_name, :total_unit, tool_units_attributes: [:id, :number, :medal, :_destroy])
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new; end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new
     @user = User.new
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,8 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "bootstrap";
 import "../stylesheets/application.scss";
+require("jquery")
+require("@nathanvda/cocoon")
 
 Rails.start()
 Turbolinks.start()

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,0 +1,8 @@
+class Tool < ApplicationRecord
+  belongs_to :user
+  has_many :tool_units, dependent: :destroy, inverse_of: :tool
+  accepts_nested_attributes_for :tool_units, allow_destroy: true, reject_if: :all_blank
+
+  validates :store_name, presence: true, length: { maximum: 255 }
+  validates :total_unit, presence: true, length: { maximum: 255 }
+end

--- a/app/models/tool_unit.rb
+++ b/app/models/tool_unit.rb
@@ -1,0 +1,6 @@
+class ToolUnit < ApplicationRecord
+  belongs_to :tool, inverse_of: :tool_units
+
+  validates :number, presence: true, length: { maximum: 255 }
+  validates :medal, length: { maximum: 255 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :tools, dependent: :destroy
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
@@ -8,4 +10,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :first_name, presence: true, length: { maximum: 255 }
   validates :last_name, presence: true, length: { maximum: 255 }
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -15,7 +15,7 @@
         </div>
         <div class="offcanvas-body">
           <ul class="navbar-nav">
-            <li class="nav-item"><%= link_to (t 'defaults.tool_inputs'), '#', class: 'nav-link' %></li>
+            <li class="nav-item"><%= link_to (t 'defaults.tool_inputs'), new_tool_path, class: 'nav-link' %></li>
             <li class="nav-item"><%= link_to (t 'defaults.login'), login_path , class: 'nav-link' %></li>
           </ul>
         </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,8 +16,8 @@
         <div class="offcanvas-body">
           <ul class="navbar-nav">
             <li class="nav-item"><%= link_to (t 'defaults.home'), root_path, method: :get, class: 'nav-link' %></li>
-            <li class="nav-item"><%= link_to (t 'defaults.lists'), '#', class: 'nav-link' %></li>
-            <li class="nav-item"><%= link_to (t 'defaults.tool_inputs'), '#', class: 'nav-link' %></li>
+            <li class="nav-item"><%= link_to (t 'defaults.lists'), tools_path, class: 'nav-link' %></li>
+            <li class="nav-item"><%= link_to (t 'defaults.tool_inputs'), new_tool_path, class: 'nav-link' %></li>
             <li class="nav-item"><%= link_to (t 'defaults.logout'), logout_path, method: :delete, class: 'nav-link' %></li>
           </ul>
         </div>

--- a/app/views/tools/_crud_menus.html.erb
+++ b/app/views/tools/_crud_menus.html.erb
@@ -1,0 +1,12 @@
+<ul class='crud-menu-btn list-inline float-right'>
+  <li class="list-inline-item">
+    <%= link_to '#', id: "button-edit-#{tool.id}" do %>
+      <%= icon 'fa', 'pen' %>
+    <% end %>
+  </li>
+  <li class="list-inline-item">
+    <%= link_to '#', id: "button-delete-#{tool.id}" do %>
+      <%= icon 'fas', 'trash' %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with model: tool, local: true do |f| %>
+  <div class="container">
+    <div class="col-auto">
+      <div class="form-group">
+      <%= f.label :store_name %>
+      <%= f.text_field :store_name, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="col-auto">
+      <div class="form-group">
+        <%= f.label :total_unit %>
+        <%= f.text_field :total_unit, class: 'form-control' %>
+      </div>  
+    </div>
+
+    <div class="unit">
+      <!-- 台番・差枚入力フィールド -->
+      <%= f.fields_for :tool_units do |n| %>
+        <%= render "tools/tool_unit_fields", f: n %>
+      <% end %>
+      <!-- 追加フィールドの表示場所 -->
+      <div id="add-tool-unit-fields-point"></div>
+      <!-- フィールド追加ボタン -->
+      <%= link_to_add_association "入力フォームを追加", f, :tool_units,
+      class: 'btn btn-dark',
+      data: {
+      association_insertion_node: '#add-tool-unit-fields-point',
+      association_insertion_method: 'before'
+      } %>
+    </div>
+    <%= f.submit (t 'tools.new.output'), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/tools/_tool.html.erb
+++ b/app/views/tools/_tool.html.erb
@@ -1,0 +1,21 @@
+<div class="col-sm-12 col-lg-4 mb-3">
+  <div id="tool-id-<%= tool.id %>">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title">
+          <%= link_to tool.store_name, tool_path(tool) %>
+        </h4>
+        <div class='mr10 float-right'>
+          <a href="#"><%= icon 'fas', 'trash', class: 'pr-1' %></a>
+          <a href="#"><%= icon 'fa', 'pen' %></a>
+        </div>
+        <ul class="list-inline">
+          <li class="list-inline-item">
+            <%= icon 'far', 'calendar' %>
+            <%= l tool.created_at, format: :long %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tools/_tool_unit_fields.html.erb
+++ b/app/views/tools/_tool_unit_fields.html.erb
@@ -1,0 +1,19 @@
+<div class="nested-fields">
+  <div class="row">
+    <div class="col">
+      <div class="form-group">
+        <%= f.number_field :number, class: 'form-control', placeholder: '台番' %>
+      </div>
+    </div>
+    <div class="col">
+      <div class="form-group">
+        <%= f.number_field :medal, class: 'form-control', placeholder: '差枚' %>
+      </div>
+    </div>
+    <div class="col">
+      <div class="form-group">
+        <%= link_to_remove_association "削除", f, class: 'btn btn-danger' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -1,0 +1,14 @@
+<div class="container pt-3">
+  <!-- 掲示板一覧 -->
+  <div class="row">
+    <div class="col-12">
+      <div class="row">
+        <% if @tools.present? %>
+          <%= render @tools %>
+        <% else %>
+          <p><%= t('.no_result') %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tools/new.html.erb
+++ b/app/views/tools/new.html.erb
@@ -1,0 +1,9 @@
+ <div class="container">
+   <div class="row">
+     <div class="col-lg-8 offset-lg-2">
+       <h1><%= t('.title') %></h1>
+       <%= render 'form', { tool: @tool } %>
+     </div>
+   </div>
+ </div>
+ 

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:store_name, @tool.store_name) %>
+<div class="container pt-5">
+  <div class="row mb-3">
+    <div class="col-lg-8 offset-lg-2">
+      <h1><%= t('.title') %></h1>
+      <!-- ツール出力結果内容 -->
+      <article class="card">
+        <div class="card-body">
+          <div class='row'>
+            <div class='col-md-9'>
+              <h3 class="d-inline"><%= @tool.store_name %></h3>
+              <%= render 'crud_menus', tool: @tool if current_user.own?(@tool) %>
+              <ul class="list-inline">
+                <li class="list-inline-item">出力時刻：<%= l @tool.created_at, format: :long  %></li>
+              </ul>
+              <ul class="list-inline">
+                <li class="list-inline-item">パチスロ総設置台数：<%= @tool.total_unit %></li>
+              </ul>
+              <ul class="list-inline">
+                <li class="list-inline-item">台番：<%= @tool_units.number %></li>
+                <li class="list-inline-item">差枚：<%= @tool_units.medal %></li>
+              </ul>
+            </div>
+          </div>
+          <!-- ここに出力結果が表示されるようにしたい。 -->
+        </div>
+      </article>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,7 @@ module Arisou
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
+
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,3 +10,8 @@ ja:
         password_confirmation: 'パスワード確認'
         last_name: '姓'
         first_name: '名'
+      tool:
+        store_name: '店舗名'
+        total_unit: 'パチスロ総設置台数'
+        unit_number: '台番'
+        medal: '差枚'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,8 @@ ja:
     login: 'ログイン'
     register: '登録'
     logout: 'ログアウト'
+    message:
+      require_login: 'ログインしてください'
     home: 'ホーム'
     lists: 'マイページ'
     tool_inputs: 'ツール新規入力'
@@ -23,17 +25,15 @@ ja:
       fail: 'ログインに失敗しました'
     destroy:
       success: 'ログアウトしました'
-  tool_inputs:
+  tools:
     new:
       title: 'ツール新規入力'
-  tool_outputs:
+      output: '出力する'
     index:
       title: 'ツール出力結果一覧'
-      no_result: 'ツール出力結果がありません'
+      no_result: '出力されたツール結果がありません。'
     show:
       title: 'ツール出力結果'
-    edit:
-      title: 'ツール出力結果編集'
-  lists:
-    index:
-      title: 'マイページ'
+    create:
+      success: 'ツール出力に成功しました'
+      fail: 'ツール出力に失敗しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
+  resources :tools, only: %i[index new create show]
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/db/migrate/20230416101558_create_tools.rb
+++ b/db/migrate/20230416101558_create_tools.rb
@@ -1,0 +1,11 @@
+class CreateTools < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tools do |t|
+      t.string :store_name, null: false
+      t.integer :total_unit, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230422083041_create_tool_units.rb
+++ b/db/migrate/20230422083041_create_tool_units.rb
@@ -1,0 +1,11 @@
+class CreateToolUnits < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tool_units do |t|
+      t.integer :number, null: false
+      t.integer :medal
+      t.references :tool, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_09_015053) do
+ActiveRecord::Schema.define(version: 2023_04_22_083041) do
+
+  create_table "tool_units", force: :cascade do |t|
+    t.integer "number", null: false
+    t.integer "medal"
+    t.integer "tool_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tool_id"], name: "index_tool_units_on_tool_id"
+  end
+
+  create_table "tools", force: :cascade do |t|
+    t.string "store_name", null: false
+    t.integer "total_unit", null: false
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tools_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -23,4 +41,6 @@ ActiveRecord::Schema.define(version: 2023_04_09_015053) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "tool_units", "tools"
+  add_foreign_key "tools", "users"
 end

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "arisou",
   "private": true,
   "dependencies": {
+    "@nathanvda/cocoon": "^1.2.14",
     "@popperjs/core": "^2.11.7",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",
     "bootstrap": "^5.2.3",
+    "jquery": "^3.6.4",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,13 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@nathanvda/cocoon@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@nathanvda/cocoon/-/cocoon-1.2.14.tgz#aaea910e4b9c0d28d5bdcb7f3743617db46b09af"
+  integrity sha512-WcEt2vVp50de2i7rkD4O+96O1iMtMIcTBNGPocrHfcmHDujKOngoLHFF8Ektgoh8PjwFAJMxx8WyGv0BtKTjxQ==
+  dependencies:
+    jquery "^3.3.1"
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -4015,6 +4022,11 @@ jest-worker@^26.5.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery@^3.3.1, jquery@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.4.tgz#ba065c188142100be4833699852bf7c24dc0252f"
+  integrity sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
37期生の松坂です。
お手数おかけしてすみません。

以下、WEBアプリ開発コミュニティに頂いたコメントへの回答になります。
ご確認のほどよろしくお願いいたします。

### ●どこまで出来ているか
ポートフォリオのため、ツール系アプリを作成中。
必要な値を入力し、コントローラーに渡して計算を行い、結果を出力するという流れを作りたい。

1. ベースとなるUserモデルとToolモデルを作成した。
2. パラメーターに含める入力値のなかで、「台番号・メダル差枚数」を複数渡せるようにしたいので、Toolモデルを親とする子モデル「Tool_unitモデル」を生成した。
3. cocoon gemを導入し、入力フォームの追加機能を付与した。
4. 入力したパラメーター（店舗名・パチスロ総設置台数・台番号・差枚数）に対して、店舗名とパチスロ総設置台数の2つの値を保存することは出来ている。


### ●どこまで理解しているか
cocoon gemを導入し、Toolモデルに「`accepts_nested_attributes_for`」を設定することで、指定したモデル（新たに作成した子モデル「Tool_unit」）の値をパラメーターに含めることができると考えている。

アソシエーションの設定で、「`has_many :tool_units`」をToolモデルに記述することで、複数の値を許可できる。

binding.pryでデバッグを試みたところ、ビューファイルから受け取ったパラメーター「tool_params」には意図した値が含まれているため、ブラウザで入力した値はコントローラーに渡ってきているはず。

```
[2] pry(#<ToolsController>)> tool_params
=> #<ActionController::Parameters {"store_name"=>"店舗A", "total_unit"=>"400", "tool_units_attributes"=>#<ActionController::Parameters {"0"=>#<ActionController::Parameters {"number"=>"123", "medal"=>"1000", "_destroy"=>"false"} permitted: true>} permitted: true>} permitted: true>
```

### ●どこが出来ていないのか
子モデル(tool_unit)で設定したカラムの値（numberとmedal）がDBに保存されない

createアクションのところで以下のように記述した箇所において、、、、子モデルの値は`@tool`に代入されていない。
↓

`@tool = current_user.tools.build(tool_params)`

```
[3] pry(#<ToolsController>)> @tool = current_user.tools.build(tool_params)
   (0.1ms)  SELECT sqlite_version(*)
  ↳ (pry):3:in `create'
  User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  ↳ (pry):3:in `create'
=> #<Tool:0x0000000114e1df10
 id: nil,
 store_name: "店舗A",
 total_unit: 400,
 user_id: 1,
 created_at: nil,
 updated_at: nil>
```

### ●どこが分からないのか
なぜ子モデル(tool_unit)で設定したカラムの値（numberとmedal）がDBに保存されないことが分からない。

`@tool = current_user.tools.build(tool_params)`
↑ここのコードを修正することで上手く保存できるのではないかと考えたが、どこをどう修正すれば良いかが分からない。

Toolモデル（親）に「`accepts_nested_attributes_for`」を設定したことで、Tool_unitモデル（子）の内容も`@tool`に渡り、@tool.saveでDBに保存できようになると考えていたが、この考えは間違いなのでしょうか？